### PR TITLE
feat: 공통 ProfileStack 구현 (#23)

### DIFF
--- a/src/components/ProfileStack/ProfileStack.jsx
+++ b/src/components/ProfileStack/ProfileStack.jsx
@@ -1,0 +1,42 @@
+import Profile from "../Profile/Profile";
+
+const ProfileStack = ({ profiles = [], remainingCount, onClick }) => {
+  const visibleProfiles = profiles.slice(0, 3);
+
+  return (
+    <div className="flex items-center">
+      {/* 프로필 이미지들 (최대 3개, sm 크기 고정) */}
+      {visibleProfiles.map((profile, index) => (
+        <div
+          key={profile.id || index}
+          className="relative"
+          style={{
+            marginLeft: index > 0 ? "-10px" : "0",
+            zIndex: index + 1,
+          }}
+        >
+          <Profile
+            src={profile.src}
+            alt={profile.alt || `프로필 ${index + 1}`}
+            size="sm" // sm 크기 고정
+            bordered
+            onClick={onClick}
+          />
+        </div>
+      ))}
+
+      {remainingCount > 0 && (
+        <div
+          className="relative flex items-center justify-center bg-white rounded-full border border-gray-300 text-gray-600 font-medium w-7 h-7 text-xs"
+          style={{
+            marginLeft: "-10px",
+            zIndex: 4,
+          }}
+        >
+          +{remainingCount}
+        </div>
+      )}
+    </div>
+  );
+};
+export default ProfileStack;

--- a/src/components/ProfileStack/README.md
+++ b/src/components/ProfileStack/README.md
@@ -1,0 +1,56 @@
+# ProfileStack 컴포넌트
+
+## 기본 사용법
+
+```jsx
+import ProfileStack from './components/ProfileStack';
+
+// 기본 사용법
+<ProfileStack
+  profiles={[
+    {id: 1, src: "/user1.jpg"},
+    {id: 2, src: "/user2.jpg"},
+    {id: 3, src: "/user3.jpg"}
+  ]}
+  remainingCount={6}
+/>
+
+// 프로필 1개만
+<ProfileStack
+  profiles={[{id: 1, src: "/user1.jpg"}]}
+  remainingCount={8}
+/>
+
+// 프로필 2개
+<ProfileStack
+  profiles={[
+    {id: 1, src: "/user1.jpg"},
+    {id: 2, src: "/user2.jpg"}
+  ]}
+  remainingCount={7}
+/>
+
+// 클릭 이벤트
+<ProfileStack
+  profiles={profiles}
+  remainingCount={5}
+  onClick={() => handleStackClick()}
+/>
+
+// 남은 인원 없음 (+숫자 표시 안됨)
+<ProfileStack
+  profiles={[
+    {id: 1, src: "/user1.jpg"},
+    {id: 2, src: "/user2.jpg"}
+  ]}
+  remainingCount={0}
+/>
+```
+
+## Props
+
+| Prop             | 타입                     | 기본값 | 설명                 |
+| ---------------- | ------------------------ | ------ | -------------------- |
+| `profiles`       | `Array<{id, src, alt?}>` | `[]`   | 프로필 데이터 배열   |
+| `remainingCount` | `number`                 | `0`    | 남은 인원 수 (+숫자) |
+| `onClick`        | `() => void`             | -      | 클릭 이벤트 핸들러   |


### PR DESCRIPTION
## 📌 PR 개요

- 프로필이미지가 여러개 보여지는 리스트를 구현했습니다.

## 🔍 관련 이슈

- Closes #이슈번호  
  (ex. Closes #23)

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [o ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 프로필이미지가 여러개 보여지는 리스트를 구현했습니다.
- 3개가 초과되면 그 후 초과되는 수 많큼 이미지가 보여집니다.  
- profiles: 프로필 객체 배열 ({id, src, alt?})

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [o] 코드가 정상 동작함
- [o] 빌드 및 실행 확인 완료
- [o] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 추후 프로필 컴포넌트에서 디폴트 이미지 크기 수정 후 프로필 이미지 크기 다시 확인해야 합니다. (이슈로 남기겠습니다.)
