### PR TITLE
feat: 공통 BadgeList 컴포넌트 구현 (#26)

### DIFF
--- a/src/components/BadgeList/BadgeList.jsx
+++ b/src/components/BadgeList/BadgeList.jsx
@@ -1,0 +1,48 @@
+import { useMemo, useState } from "react";
+import EmojiBadge from "../EmojiBadge/EmojiBadge";
+
+//예시 뱃지리스트 리스트를 사용하시는 페이지에서 쓰세요
+// const mockBadges: Badge[] = [
+//   { emoji: "👍", count: 2 },
+//   { emoji: "😍", count: 1 },
+//   // ...
+// ];
+
+const BadgeList = ({ badges = [], showMore = true }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const maxVisible = 3;
+  const expandedVisible = 8;
+
+  const sortedBadges = useMemo(() => {
+    return [...badges].sort((a, b) => b.count - a.count);
+  }, [badges]);
+
+  const visibleBadges = isExpanded
+    ? sortedBadges.slice(0, expandedVisible)
+    : sortedBadges.slice(0, maxVisible);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {visibleBadges.map((badge, index) => (
+          <div key={index} className="basis-1/5">
+            <EmojiBadge emoji={badge.emoji} count={badge.count} />
+          </div>
+        ))}
+      </div>
+
+      {/* showMore가 true일때 나오는 더보기, 접기 버튼입니다. */}
+      {showMore && sortedBadges.length > maxVisible && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-sm text-blue-600 underline"
+        >
+          {isExpanded ? "접기 ▲" : "더보기 ▼"}
+        </button>
+      )}
+    </>
+  );
+};
+
+export default BadgeList;


### PR DESCRIPTION
## 📌 PR 개요

- 공통 BadgeList 컴포넌트 구현

## 🔍 관련 이슈

- Closes #26   

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 공통 컴포넌트 BadgeList 추가
- EmojiBadge를 모아 보여주는 리스트 컴포넌트
- 상위 3개만 기본 표시, 더보기 / 접기 토글 버튼으로 최대 8개까지 확장 (버튼 추후 수정)
- 항상 count 기준 내림차순 정렬 후 출력

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

<img width="295" height="133" alt="image" src="https://github.com/user-attachments/assets/24984147-5d43-484e-9305-5211262863b5" />

<img width="233" height="99" alt="image" src="https://github.com/user-attachments/assets/8c2e1c3b-54ee-421a-9976-f2af27cd4237" />



## 🤝 기타 참고 사항

- 예시 뱃지 리스트는 어떤식으로 들어가는지 모르는분을 위해 목업을 넣었습니다.
- 실제 사용할 땐 공통 뱃지 컴포넌트로 리스트를 직접 만들어서 전달해야 합니다.
