### PR TITLE
feat: axios base api 및 도메인별 api 구현 #44

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "axios": "^1.12.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      axios:
+        specifier: ^1.12.2
+        version: 1.12.2
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -791,12 +794,18 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -824,6 +833,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -869,6 +882,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -926,6 +943,10 @@ packages:
   defined@1.0.1:
     resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.1:
     resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
     engines: {node: '>=8'}
@@ -943,6 +964,9 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.223:
     resolution: {integrity: sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==}
@@ -957,6 +981,22 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
@@ -1071,6 +1111,19 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
@@ -1092,6 +1145,13 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1113,12 +1173,24 @@ packages:
     resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -1324,6 +1396,10 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1331,6 +1407,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1478,6 +1562,9 @@ packages:
   pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2311,6 +2398,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.2
@@ -2320,6 +2409,14 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  axios@1.12.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -2345,6 +2442,11 @@ snapshots:
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
   bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   callsites@3.1.0: {}
 
@@ -2391,6 +2493,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@8.3.0: {}
 
   concat-map@0.0.1: {}
@@ -2434,6 +2540,8 @@ snapshots:
 
   defined@1.0.1: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.1: {}
 
   detective@5.2.1:
@@ -2450,6 +2558,11 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   electron-to-chromium@1.5.223: {}
 
@@ -2463,6 +2576,21 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -2618,6 +2746,16 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   fraction.js@4.3.7: {}
 
   fs-extra@10.1.0:
@@ -2634,6 +2772,23 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -2656,9 +2811,17 @@ snapshots:
 
   globals@16.4.0: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -2825,12 +2988,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@3.1.2:
     dependencies:
@@ -2952,6 +3123,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   pretty-hrtime@1.0.3: {}
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://rolling-api.vercel.app",
+  timeout: 5000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 추후 에러페이지 여러 개 필요해 질 때 분기 추가
+api.interceptors.response.use(
+  (res) => res,
+  (err) => Promise.reject(err)
+);
+
+export default api;

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -10,7 +10,7 @@ const api = axios.create({
 
 // 추후 에러페이지 여러 개 필요해 질 때 분기 추가
 api.interceptors.response.use(
-  (res) => res,
+  (res) => res.data,
   (err) => Promise.reject(err)
 );
 

--- a/src/api/images.js
+++ b/src/api/images.js
@@ -1,0 +1,5 @@
+import api from "./api";
+
+export const getProfileImages = () => api.get("/profile-images/");
+
+export const getBackgroundImages = () => api.get("/background-images/");

--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -1,0 +1,19 @@
+import api from "./api";
+
+const END_POINT = "/19-8/messages/";
+
+// 필요시 활성화
+
+// export const getMessage = (id) => api.get(`${END_POINT}${id}`);
+
+// export const patchMessage = (id) => api.patch(`${END_POINT}${id}`);
+
+// export const putMessage = (id) => api.put(`${END_POINT}${id}`);
+
+export const createMessage = (recipient_id, data) =>
+  api.post(`/19-8/recipients/${recipient_id}/messages`, data);
+
+export const getMessageList = (recipient_id, options) =>
+  api.get(`/19-8/recipients/${recipient_id}/messages`, { params: options });
+
+export const deleteMessage = (id) => api.delete(`${END_POINT}${id}`);

--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -1,19 +1,28 @@
 import api from "./api";
+import { throwIfMissing } from "../utils/validators";
 
 const END_POINT = "/19-8/messages/";
 
 // 필요시 활성화
 
-// export const getMessage = (id) => api.get(`${END_POINT}${id}`);
+// export const getMessage = (id) => api.get(`${END_POINT}${id}/`);
 
-// export const patchMessage = (id) => api.patch(`${END_POINT}${id}`);
+// export const patchMessage = (id) => api.patch(`${END_POINT}${id}/`);
 
-// export const putMessage = (id) => api.put(`${END_POINT}${id}`);
+// export const putMessage = (id) => api.put(`${END_POINT}${id}/`);
 
-export const createMessage = (recipient_id, data) =>
-  api.post(`/19-8/recipients/${recipient_id}/messages`, data);
+export const createMessage = (
+  recipient_id = throwIfMissing("recipient_id"),
+  data = throwIfMissing("data")
+) => api.post(`/19-8/recipients/${recipient_id}/messages/`, data);
 
-export const getMessageList = (recipient_id, options) =>
-  api.get(`/19-8/recipients/${recipient_id}/messages`, { params: options });
+export const getMessageList = (
+  recipient_id = throwIfMissing("recipient_id"),
+  options
+) =>
+  api.get(`/19-8/recipients/${recipient_id}/messages/`, {
+    params: options,
+  });
 
-export const deleteMessage = (id) => api.delete(`${END_POINT}${id}`);
+export const deleteMessage = (id = throwIfMissing("id")) =>
+  api.delete(`${END_POINT}${id}/`);

--- a/src/api/papers.js
+++ b/src/api/papers.js
@@ -1,4 +1,5 @@
 import api from "./api";
+import { throwIfMissing } from "../utils/validators";
 
 const END_POINT = "/19-8/recipients/";
 
@@ -6,8 +7,11 @@ export const getPaperList = (options = {}) =>
   api.get(END_POINT, {
     params: options,
   });
-export const createPaper = (data) => api.post(END_POINT, data);
+export const createPaper = (data = throwIfMissing("data")) =>
+  api.post(END_POINT, data);
 
-export const getTargetPaper = (id) => api.get(`${END_POINT}${id}/`);
+export const getTargetPaper = (id = throwIfMissing("id")) =>
+  api.get(`${END_POINT}${id}/`);
 
-export const deletePaper = (id) => api.delete(`${END_POINT}${id}/`);
+export const deletePaper = (id = throwIfMissing(id)) =>
+  api.delete(`${END_POINT}${id}/`);

--- a/src/api/papers.js
+++ b/src/api/papers.js
@@ -13,5 +13,5 @@ export const createPaper = (data = throwIfMissing("data")) =>
 export const getTargetPaper = (id = throwIfMissing("id")) =>
   api.get(`${END_POINT}${id}/`);
 
-export const deletePaper = (id = throwIfMissing(id)) =>
+export const deletePaper = (id = throwIfMissing("id")) =>
   api.delete(`${END_POINT}${id}/`);

--- a/src/api/papers.js
+++ b/src/api/papers.js
@@ -1,0 +1,13 @@
+import api from "./api";
+
+const END_POINT = "/19-8/recipients/";
+
+export const getPaperList = (options = {}) =>
+  api.get(END_POINT, {
+    params: options,
+  });
+export const createPaper = (data) => api.post(END_POINT, data);
+
+export const getTargetPaper = (id) => api.get(`${END_POINT}${id}/`);
+
+export const deletePaper = (id) => api.delete(`${END_POINT}${id}/`);

--- a/src/api/reactions.js
+++ b/src/api/reactions.js
@@ -1,8 +1,10 @@
 import api from "./api";
 import { throwIfMissing } from "../utils/validators";
 
-export const reactToPaper = (recipient_id = throwIfMissing("recipinet_id")) =>
-  api.post(`/19-8/recipients/${recipient_id}/reactions/`);
+export const reactToPaper = (
+  recipient_id = throwIfMissing("recipinet_id"),
+  data = throwIfMissing("data")
+) => api.post(`/19-8/recipients/${recipient_id}/reactions/`, data);
 
 export const getPaperReactions = (
   recipient_id = throwIfMissing("recipinet_id"),

--- a/src/api/reactions.js
+++ b/src/api/reactions.js
@@ -1,0 +1,7 @@
+import api from "./api";
+
+export const reactToPaper = (recipient_id) =>
+  api.post(`/19-8/recipients/${recipient_id}/reactions/`);
+
+export const getPaperReactions = (recipient_id, options = {}) =>
+  api.get(`/19-8/recipients/${recipient_id}/reactions/`, { params: options });

--- a/src/api/reactions.js
+++ b/src/api/reactions.js
@@ -1,7 +1,11 @@
 import api from "./api";
+import { throwIfMissing } from "../utils/validators";
 
-export const reactToPaper = (recipient_id) =>
+export const reactToPaper = (recipient_id = throwIfMissing("recipinet_id")) =>
   api.post(`/19-8/recipients/${recipient_id}/reactions/`);
 
-export const getPaperReactions = (recipient_id, options = {}) =>
+export const getPaperReactions = (
+  recipient_id = throwIfMissing("recipinet_id"),
+  options = {}
+) =>
   api.get(`/19-8/recipients/${recipient_id}/reactions/`, { params: options });

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,3 @@
+export const throwIfMissing = (name) => {
+  throw new Error(`${name}값은 필수입니다.`);
+};


### PR DESCRIPTION
## 📌 PR 개요

- axios base api 및 도메인별 api 구현

## 🔍 관련 이슈

- Closes #44

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- axios baseAPI(`api.js`) 생성
- 도메인별 API 모듈(`papers.js`, `messages.js`, `images.js`, `reactions.js`) 생성
- 필수입력 검증 유틸(`validators.js`) 생성

## 🧪 테스트 방법
- `/papers`, `/messages` API 호출 정상 동작 확인
- message 작성 후 목록에서 정상 조회
- 삭제 API 호출 시 204 응답 및 목록에서 제거 확인

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고 사항

- baseAPI에서 응답을 `res.data`로 통일 → UI 단 코드 간소화
- `throwIfMissing` 유틸로 필수 파라미터 검증
