### PR TITLE
feat: posted 페이지 MessageCardList 컴포넌트 구현 (#55)

### DIFF
--- a/src/pages/PostedPage/components/MessageCardList.jsx
+++ b/src/pages/PostedPage/components/MessageCardList.jsx
@@ -1,0 +1,39 @@
+//import { Link } from 'react-router-dom';
+import Button from '@/components/Button/Button';
+
+const MessageCardList = () => {
+  // 임시 데이터
+  const messages = [
+    { id: 1, author: '유진', content: '축하해 🎉' },
+    { id: 2, author: '톰', content: '행복하길 바래 😄' },
+    { id: 3, author: '수지', content: '화이팅!' },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
+      {/* 첫 번째 메세지 카드 고정*/}
+      <div className="flex justify-center items-center h-[280px] rounded-[16px] bg-white shadow-[0_2px_12px_0_rgba(0,0,0,0.08)]">
+        <Button shape="circle" iconName="plus" variant="gray" />
+      </div>
+      {/* <Link
+          to="/post"
+          aria-label="새 메시지 작성 페이지로 이동"
+          className="flex justify-center items-center h-[280px] rounded-[16px] bg-white shadow-[0_2px_12px_0_rgba(0,0,0,0.08)]"
+        >
+          <Button shape="circle" iconName="plus" variant="gray" />
+        </Link> */}
+      {/* 임시 카드 리스트*/}
+      {messages.map((msg) => (
+        <div
+          key={msg.id}
+          className="rounded-xl border p-4 bg-white flex flex-col gap-2"
+        >
+          <p className="font-semibold">{msg.author}</p>
+          <p className="text-gray-700">{msg.content}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MessageCardList;


### PR DESCRIPTION
## 📌 PR 개요

- 반응형 메시지 카드 리스트(MessageCardList) 레이아웃 구현
- 첫 번째 고정 Add 카드(+) 버튼 UI 추가

## 🔍 관련 이슈

- Closes #55

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- grid 레이아웃을 사용해 반응형 구성: 1열 → 2열(sm) → 3열(xl) 구조

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부
<img width="1306" height="506" alt="image" src="https://github.com/user-attachments/assets/62148b66-331e-40ec-be76-7c324b7aebf5" />
<img width="964" height="414" alt="image" src="https://github.com/user-attachments/assets/cacafa05-36ea-44ea-82c4-547fbcb63b5e" />
<img width="468" height="599" alt="image" src="https://github.com/user-attachments/assets/c3bf316f-c27f-45cb-8f2e-c13e47a3ed39" />




## 🤝 기타 참고 사항

- react-router 설정이 main에 머지된 이후, Link로 /post 페이지 이동 기능 연동 예정 (현재 Link 주석처리)
- 임시 데이터(messages) 기반의 카드 리스트 표시
