### PR TITLE
feat: postpage{id} Popover 컴포넌트 구현 (#104)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,29 @@
 import './globals.css';
 import './App.css';
 import MainPage from './pages/MainPage/MainPage';
+import {
+  Popover,
+  PopoverTrigger,
+  EmojiContent,
+  ShareContent,
+} from './pages/PostedPage/components/Popover';
 
 function App() {
   return (
     <>
       <MainPage />
+      <div className="ml-60 border">
+        <Popover>
+          <PopoverTrigger type="emoji" />
+          <EmojiContent />
+        </Popover>
+      </div>
+      <div className="ml-60 border mt-60">
+        <Popover>
+          <PopoverTrigger type="share" />
+          <ShareContent />
+        </Popover>
+      </div>
     </>
   );
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -34,6 +34,7 @@
   --color-gray200: #eeeeee;
   --color-gray250: #dadcdf;
   --color-gray300: #cccccc;
+  --color-gray350: #b6b6b6;
   --color-gray400: #999999;
   --color-gray500: #555555;
   --color-gray600: #4a4a4a;

--- a/src/pages/PostedPage/components/Popover/Popover.jsx
+++ b/src/pages/PostedPage/components/Popover/Popover.jsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PopoverContext from './PopoverContext';
+
+export const Popover = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef(null);
+
+  const open = () => setIsOpen(true);
+  const close = () => setIsOpen(false);
+  const toggle = () => setIsOpen((prev) => !prev);
+
+  // 외부 클릭, ESC 키 감지
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscapekey = (event) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleEscapekey);
+    }
+  }, [isOpen]);
+
+  const value = { isOpen, open, close, toggle };
+
+  return (
+    <PopoverContext.Provider value={value}>
+      <div ref={ref} className="relative inline-block">
+        {children}
+      </div>
+    </PopoverContext.Provider>
+  );
+};

--- a/src/pages/PostedPage/components/Popover/PopoverContents/PopoverContent.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverContents/PopoverContent.jsx
@@ -1,0 +1,13 @@
+import React, { useContext } from 'react';
+import PopoverContext from '../PopoverContext';
+
+export const PopoverContent = ({ children }) => {
+  const { isOpen } = useContext(PopoverContext);
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute mt-2 right-0 rounded-lg border border-gray350 bg-white shadow-[0px_2px_12px_0px_#00000014]">
+      {children}
+    </div>
+  );
+};

--- a/src/pages/PostedPage/components/Popover/PopoverContents/emojiContent.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverContents/emojiContent.jsx
@@ -1,0 +1,39 @@
+import EmojiBadge from '@/EmojiBadge/EmojiBadge';
+import { PopoverContent } from './PopoverContent';
+
+// 데이터 연결 후 삭제 예정
+const reactions = [
+  { id: 24, recipientId: 2, emoji: '😀', count: 15 },
+  { id: 25, recipientId: 3, emoji: '🤣', count: 9 },
+  { id: 26, recipientId: 4, emoji: '😍', count: 24 },
+  { id: 27, recipientId: 5, emoji: '😭', count: 7 },
+  { id: 28, recipientId: 6, emoji: '😎', count: 12 },
+  { id: 29, recipientId: 7, emoji: '😡', count: 3 },
+  { id: 30, recipientId: 8, emoji: '🤔', count: 5 },
+  { id: 31, recipientId: 9, emoji: '😴', count: 2 },
+  { id: 32, recipientId: 10, emoji: '😇', count: 10 },
+];
+
+export const EmojiContent = ({ emojis = reactions }) => {
+  // 모바일/태블릿/데스크탑 (모바일은 현재 EmojiBadge 크기가 달라 찌그러짐)
+  const gridStyles = `
+    grid grid-cols-3 w-[171px] h-[66px] gap-[10px] m-[24px]
+    sm:w-[200px] sm:h-[86px]
+    md:grid-cols-4 md:w-[264px]
+  `;
+
+  return (
+    <PopoverContent>
+      <div className={gridStyles}>
+        {emojis.slice(0, 8).map((emoji, index) => {
+          const hideOnMobile = index >= 6 && 'hidden md:flex';
+          return (
+            <span key={index} className={`flex justify-center ${hideOnMobile}`}>
+              <EmojiBadge emoji={emoji.emoji} count={emoji.count} />
+            </span>
+          );
+        })}
+      </div>
+    </PopoverContent>
+  );
+};

--- a/src/pages/PostedPage/components/Popover/PopoverContents/shareContent.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverContents/shareContent.jsx
@@ -1,0 +1,35 @@
+import { PopoverContent } from './PopoverContent';
+
+export const ShareContent = () => {
+  const buttonClasses = `
+    px-[16px] py-[12px] w-[138px] text-left
+    hover:bg-gray100 hover:cursor-pointer
+  `;
+
+  const handleKakaoShare = () => {
+    console.log('KakaoTalk share clicked');
+  };
+
+  const handleUrlShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      // Toast 알림
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+      // Toast 알림
+    }
+  };
+
+  return (
+    <PopoverContent>
+      <div className="flex flex-col mx-[1px] my-[10px]">
+        <button className={buttonClasses} onClick={handleKakaoShare}>
+          카카오톡 공유
+        </button>
+        <button className={buttonClasses} onClick={handleUrlShare}>
+          URL 공유
+        </button>
+      </div>
+    </PopoverContent>
+  );
+};

--- a/src/pages/PostedPage/components/Popover/PopoverContext.js
+++ b/src/pages/PostedPage/components/Popover/PopoverContext.js
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+// Popover Context 생성
+const PopoverContext = createContext(null);
+
+export default PopoverContext;

--- a/src/pages/PostedPage/components/Popover/PopoverTrigger.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverTrigger.jsx
@@ -1,0 +1,32 @@
+import React, { useContext } from 'react';
+import PopoverContext from './PopoverContext';
+import Button from '@/components/Button/Button';
+
+export const PopoverTrigger = ({ type }) => {
+  const { toggle } = useContext(PopoverContext);
+
+  return (
+    <>
+      {type === 'emoji' && (
+        <Button
+          onClick={toggle}
+          size="custom"
+          paddingX={6}
+          paddingY={6}
+          variant="noLine"
+          iconName="arrowDown"
+        />
+      )}
+      {type === 'share' && (
+        <Button
+          onClick={toggle}
+          size="custom"
+          paddingX={16}
+          paddingY={6}
+          variant="outlined"
+          iconName="share"
+        />
+      )}
+    </>
+  );
+};

--- a/src/pages/PostedPage/components/Popover/index.js
+++ b/src/pages/PostedPage/components/Popover/index.js
@@ -1,0 +1,4 @@
+export { Popover } from './Popover';
+export { PopoverTrigger } from './PopoverTrigger';
+export { ShareContent } from './PopoverContents/ShareContent';
+export { EmojiContent } from './PopoverContents/EmojiContent';


### PR DESCRIPTION
## 📌 PR 개요

- `post/{id}` 페이지의 `SubHeader` 에서 사용할 `Popover` 컴포넌트 구현

## 🔍 관련 이슈

- Closes #104

## 🔧 변경 유형

- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
### `Popover.jsx`
- 트리거와 컨텐츠에게 `Context`를 제공
- `children`으로 `PopoverTrigger`, `PopoverContent`를 props로 받아서 그림
- `useEffect`를 사용하여 외부 클릭 및 Esc 키로 팝업 닫히도록 함

### `PopoverTrigger.jsx`
- `PopoverTrigger`로 사용될 요소의 타입을 `props`로 받음
- `Popover`가 쓰이는 곳이 적기 때문에 해당 파일에서 모든 경우의 Trigger를 구현할 예정
- 반응형 미적용

### `PopoverContent.jsx`
- 컨텐츠를 담을 컴포넌트

### `EmojiContent.jsx`, `ShareContent.jsx`
- 팝오버 컴포넌트에 들어갈 내용 정의
- `PopoverContent`를 `import` 하여 `children`의 props로 정의한 내용 전달

### `index.jsx`
- `Popover` 컴포넌트 활용을 위해 export 파일들을 묶은 파일

### `globals.css`
- 정의되지 않은 `gray350: #b6b6b6` 정의

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷

<img width="329" height="170" alt="image" src="https://github.com/user-attachments/assets/e052fd57-6b24-44ba-ae7f-ffdeca03d0f8" />

## 🤝 기타 참고 사항

- `Button` 디자인 미완성입니다

- 사용 예시

```
import {
  Popover,
  PopoverTrigger,
  ShareContent,
  EmojiContent,
} from './pages/PostedPage/components/Popover';
...

 <Popover>
        <PopoverTrigger type="emoji" />
        <EmojiContent type="emoji" />
      </Popover>
      <Popover>
        <PopoverTrigger type="share" />
        <ShareContent type="share" />
      </Popover>
```
