### PR TITLE
feat: SubHeader 컴포넌트 구현 (#103)

### DIFF
--- a/src/components/Divider/Divider.jsx
+++ b/src/components/Divider/Divider.jsx
@@ -1,16 +1,14 @@
-const Divider = ({ orientation = 'horizontal' }) => {
+import clsx from 'clsx';
+
+const Divider = ({ orientation = 'horizontal', className }) => {
   const isVertical = orientation === 'vertical';
+  const classes = clsx(
+    className,
+    isVertical ? 'w-px h-[80%] bg-gray200' : 'border-0 h-px w-full bg-gray200',
+  );
 
   return (
-    <hr
-      role="separator"
-      aria-orientation={orientation}
-      className={
-        isVertical
-          ? 'border-0 w-px h-full bg-gray200'
-          : 'border-0 h-px w-full bg-gray200'
-      }
-    />
+    <hr role="separator" aria-orientation={orientation} className={classes} />
   );
 };
 

--- a/src/pages/PostedPage/components/Popover/PopoverTrigger.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverTrigger.jsx
@@ -35,7 +35,9 @@ export const PopoverTrigger = ({ type }) => {
           paddingY={6}
           variant="outlined"
           iconName="add"
-        />
+        >
+          <span className="hidden md:inline">추가</span>
+        </Button>
       )}
     </>
   );

--- a/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
+++ b/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
@@ -1,0 +1,100 @@
+import Divider from '@/components/Divider/Divider';
+import EmojiBadge from '@/EmojiBadge/EmojiBadge';
+import ProfileStack from '@/components/ProfileStack/ProfileStack';
+import {
+  Popover,
+  PopoverTrigger,
+  ShareContent,
+  EmojiContent,
+  EmojiPickerContent,
+} from '../Popover';
+
+// 임시 데이터
+const DEFAULT = {
+  NAME: 'Ashley Kim',
+  PROFILES: [
+    { id: 1, src: '/images/default_profile.png' },
+    { id: 2, src: '/images/default_profile.png' },
+    { id: 3, src: '/images/default_profile.png' },
+  ],
+  MESSAGE_COUNT: 30,
+  TOP_REACTIONS: [
+    { emoji: '😀', count: 11 },
+    { emoji: '👍', count: 7 },
+    { emoji: '😍', count: 9 },
+  ],
+  REACTION: [
+    { id: 24, recipientId: 2, emoji: '😀', count: 15 },
+    { id: 25, recipientId: 3, emoji: '🤣', count: 9 },
+    { id: 26, recipientId: 4, emoji: '😍', count: 24 },
+    { id: 27, recipientId: 5, emoji: '😭', count: 7 },
+    { id: 28, recipientId: 6, emoji: '😎', count: 12 },
+    { id: 29, recipientId: 7, emoji: '😡', count: 3 },
+    { id: 30, recipientId: 8, emoji: '🤔', count: 5 },
+    { id: 31, recipientId: 9, emoji: '😴', count: 2 },
+    { id: 32, recipientId: 10, emoji: '😇', count: 10 },
+  ],
+};
+
+const SubHeader = ({
+  name = DEFAULT.NAME,
+  profiles = DEFAULT.PROFILES,
+  messageCount = DEFAULT.MESSAGE_COUNT,
+  topReaction = DEFAULT.TOP_REACTIONS,
+  reactions = DEFAULT.REACTION,
+}) => {
+  return (
+    <div className="flex justify-center border border-gray200 w-full py-[13px]">
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center w-full max-w-[1200px] md:px-6 lg:px-0">
+        {/* left */}
+        <div className="mb-3 ml-5 md:mb-0 md:ml-0">
+          <span className="text-[28px] font-bold">To. {name}</span>
+        </div>
+        <Divider className="block md:hidden" />
+        {/* right */}
+        <div className="flex h-full items-center gap-[27px] mt-3 md:mt-0 ml-5 md:ml-0">
+          {/* visitor */}
+          <div className="hidden md:flex items-center gap-[11px]">
+            <ProfileStack
+              profiles={profiles}
+              remainingCount={messageCount - 3}
+            />
+            <div className="hidden lg:flex">
+              <span className="font-bold">{messageCount}</span>
+              <span>명이 작성했어요!</span>
+            </div>
+          </div>
+          <Divider className="hidden md:inline" orientation="vertical" />
+          {/* reactions */}
+          <div className="flex gap-[8px]">
+            {topReaction.map((reaction) => (
+              <EmojiBadge
+                key={reaction.emoji}
+                emoji={reaction.emoji}
+                count={reaction.count}
+              />
+            ))}
+            {/* Emoji Picker */}
+            <Popover>
+              <PopoverTrigger type="emoji" />
+              <EmojiContent />
+            </Popover>
+            <Popover>
+              <PopoverTrigger type="emojiPicker" />
+              <EmojiPickerContent onEmojiClick={console.log} />
+            </Popover>
+          </div>
+          <Divider orientation="vertical" />
+          <div>
+            <Popover>
+              <PopoverTrigger type="share" />
+              <ShareContent emojis={reactions} />
+            </Popover>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubHeader;


### PR DESCRIPTION
## 📌 PR 개요

- `post/{id}` 페이지에서 사용할 SubHeader 컴포넌트 구현

## 🔍 관련 이슈

- Closes #103

## 🔧 변경 유형

- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

- 


## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 
**Desktop**
<img width="1881" height="492" alt="image" src="https://github.com/user-attachments/assets/79b609dd-5199-4e90-814b-3fdd77eacd97" />

**Mobile**
<img width="450" height="973" alt="image" src="https://github.com/user-attachments/assets/232a4c01-f786-4fd9-9e32-4b0bfcf4fca4" />


## 🤝 기타 참고 사항
