### PR TITLE
refactor: PostedPage 페이지 컴포넌트 조합 (#124)

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -19,7 +19,7 @@ function Header() {
   };
 
   return (
-    <div className="sticky top-0 z-50 w-full py-3 bg-white border-b border-gray200">
+    <div className="sticky top-0 z-50 w-full h-[64px] py-3 bg-white border-b border-gray200 ">
       <div className="flex justify-between items-center w-full mx-auto px-6 max-w-[1248px]">
         <div
           className="flex items-center gap-2 cursor-pointer transition-transform duration-200 ease-in-out select-none"

--- a/src/pages/PostedPage/PostedPage.jsx
+++ b/src/pages/PostedPage/PostedPage.jsx
@@ -1,10 +1,20 @@
-import { useParams } from 'react-router-dom';
+//import { useParams } from 'react-router-dom';
+import SubHeader from './components/SubHeader/SubHeader';
+import MessageCardList from './components/MessageCardList/MessageCardList';
 
 const PostedPage = () => {
-  const { id } = useParams();
+  // const { id } = useParams();
   return (
-    <div>
-      <p> this is posted page.</p>
+    //  <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6"></div>
+    <div className="min-h-screen flex flex-col">
+      {/* SubHeader 영역 */}
+      <div className="sticky top-[64px] z-40 w-full ">
+        <SubHeader />
+      </div>
+      {/* 카드 리스트 영역 */}
+      <div className="w-full max-w-[1200px] mx-auto xl:mt-28 xl:p-0 sm:mt-8  sm:p-6 mt-8 p-5">
+        <MessageCardList />
+      </div>
     </div>
   );
 };

--- a/src/pages/PostedPage/components/MessageCard/MessageCard.jsx
+++ b/src/pages/PostedPage/components/MessageCard/MessageCard.jsx
@@ -1,5 +1,5 @@
 import Badge from '../Badge/Badge';
-import Divider from '@/components/Divider/Divder';
+import Divider from '@/components/Divider/Divider';
 import Profile from '@/components/Profile/Profile';
 
 const EX = {
@@ -23,7 +23,7 @@ const MessageCard = ({
   const date = createdAt.slice(0, 10).replace(/-/g, '.');
 
   return (
-    <div className="flex flex-col justify-between p-[24px] ph-[28px] w-[384px] h-[280px] rounded-[16px] shadow-[0_2px_12px_0_#00000014]">
+    <div className="flex flex-col justify-between p-[24px] ph-[28px] h-[280px] rounded-[16px] shadow-[0_2px_12px_0_#00000014]">
       {/* SENDER */}
       <div>
         {/* HEAD */}

--- a/src/pages/PostedPage/components/MessageCardList/MessageCardList.jsx
+++ b/src/pages/PostedPage/components/MessageCardList/MessageCardList.jsx
@@ -1,36 +1,29 @@
-//import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Button from '@/components/Button/Button';
+import MessageCard from '@/pages/PostedPage/components/MessageCard/MessageCard';
+import { MOCK_MESSAGES } from '@/pages/PostedPage/components/MessageCardList/messages';
 
 const MessageCardList = () => {
-  // 임시 데이터
-  const messages = [
-    { id: 1, author: '유진', content: '축하해 🎉' },
-    { id: 2, author: '톰', content: '행복하길 바래 😄' },
-    { id: 3, author: '수지', content: '화이팅!' },
-  ];
-
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6">
       {/* 첫 번째 메세지 카드 고정*/}
-      <div className="flex justify-center items-center h-[280px] rounded-[16px] bg-white shadow-[0_2px_12px_0_rgba(0,0,0,0.08)]">
+      <Link
+        to="/post"
+        aria-label="새 메시지 작성 페이지로 이동"
+        className="flex justify-center items-center h-[280px] rounded-[16px] bg-white shadow-[0_2px_12px_0_rgba(0,0,0,0.08)]"
+      >
         <Button shape="circle" iconName="plus" variant="gray" />
-      </div>
-      {/* <Link
-          to="/post"
-          aria-label="새 메시지 작성 페이지로 이동"
-          className="flex justify-center items-center h-[280px] rounded-[16px] bg-white shadow-[0_2px_12px_0_rgba(0,0,0,0.08)]"
-        >
-          <Button shape="circle" iconName="plus" variant="gray" />
-        </Link> */}
-      {/* 임시 카드 리스트*/}
-      {messages.map((msg) => (
-        <div
+      </Link>
+      {/* 카드 리스트 */}
+      {MOCK_MESSAGES.map((msg) => (
+        <MessageCard
           key={msg.id}
-          className="rounded-xl border p-4 bg-white flex flex-col gap-2"
-        >
-          <p className="font-semibold">{msg.author}</p>
-          <p className="text-gray-700">{msg.content}</p>
-        </div>
+          sender={msg.sender}
+          profileImageURL={msg.profileImageURL}
+          relationship={msg.relationship}
+          content={msg.content}
+          createdAt={msg.createdAt}
+        />
       ))}
     </div>
   );

--- a/src/pages/PostedPage/components/MessageCardList/messages.js
+++ b/src/pages/PostedPage/components/MessageCardList/messages.js
@@ -1,0 +1,9 @@
+export const MOCK_MESSAGES = Array.from({ length: 60 }, (_z, i) => ({
+  id: i + 1,
+  sender: `보낸이 ${i + 1}`,
+  profileImageURL: '/images/default_profile.png',
+  relationship: (i + 1) % 2 === 0 ? '친구' : '가족',
+  content: `🎉 축하 메시지 ${i + 1}번째입니다. 오늘도 행복한 하루 되세요!`,
+  font: 'Pretendard',
+  createdAt: new Date(2023, 10, (i % 30) + 1).toISOString(),
+}));

--- a/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
+++ b/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
@@ -44,7 +44,7 @@ const SubHeader = ({
   reactions = DEFAULT.REACTION,
 }) => {
   return (
-    <div className="flex justify-center border border-gray200 w-full py-[13px]">
+    <div className="flex justify-center border-b border-gray200 w-full py-[13px] bg-white">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center w-full max-w-[1200px] md:px-6 lg:px-0">
         {/* left */}
         <div className="mb-3 ml-5 md:mb-0 md:ml-0">


### PR DESCRIPTION
## 📌 PR 개요

- PostedPage 페이지 컴포넌트 조합해서 페이지를 리팩토링했습니다.

## 🔍 관련 이슈

- Closes #124

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- PostedPage 페이지 내 컴포넌트 조합 및 레이아웃 구조 리팩토링
- 반응형 리스트 영역 구현 (모바일·태블릿·데스크탑 대응)
- 헤더와 서브헤더 높이값 지정
- 카드 고정 폭 해제 및 유동형 레이아웃으로 변경
- 임시 목업 데이터를 활용해 리스트 배열 구성

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

<img width="1894" height="929" alt="image" src="https://github.com/user-attachments/assets/2de4f08c-ceff-49a3-8cfd-c1cd61de72f3" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)

- 이후 무한스크롤 로직 적용 예정
- 서브헤더 세밀한 스타일 수정 예정 (추후 직접 진행 예정)
