### PR TITLE
feat: posted 페이지 background 컴포넌트 구현 (#141)

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Layout = ({ children }) => {
+  return <div className="min-h-screen flex flex-col">{children}</div>;
+};
+
+export default Layout;

--- a/src/pages/PostedPage/PostedPage.jsx
+++ b/src/pages/PostedPage/PostedPage.jsx
@@ -1,20 +1,28 @@
-//import { useParams } from 'react-router-dom';
+// import { useParams } from 'react-router-dom';
+import Background from './components/Background/Background';
+import Layout from '../Layout';
 import SubHeader from './components/SubHeader/SubHeader';
 import MessageCardList from './components/MessageCardList/MessageCardList';
 
 const PostedPage = () => {
   // const { id } = useParams();
   return (
-    <div className="min-h-screen flex flex-col">
-      {/* SubHeader 영역 */}
-      <div className="sticky top-[64px] z-40 w-full ">
-        <SubHeader />
+    <Layout>
+      <Background
+        color={'beige'}
+        imageURL={'https://picsum.photos/id/1058/3840/2160'}
+      />
+      <div className="min-h-screen flex flex-col">
+        {/* SubHeader 영역 */}
+        <div className="sticky top-[64px] z-40 w-full ">
+          <SubHeader />
+        </div>
+        {/* 카드 리스트 영역 */}
+        <div className="w-full max-w-[1200px] mx-auto xl:mt-28 xl:p-0 sm:mt-8  sm:p-6 mt-8 p-5">
+          <MessageCardList />
+        </div>
       </div>
-      {/* 카드 리스트 영역 */}
-      <div className="w-full max-w-[1200px] mx-auto xl:mt-28 xl:p-0 sm:mt-8  sm:p-6 mt-8 p-5">
-        <MessageCardList />
-      </div>
-    </div>
+    </Layout>
   );
 };
 

--- a/src/pages/PostedPage/components/Background/Background.jsx
+++ b/src/pages/PostedPage/components/Background/Background.jsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx';
+
+const Background = ({ color = beige, imageURL }) => {
+  const colorTheme = {
+    beige: 'bg-beige200',
+    blue: 'bg-blue200',
+    purple: 'bg-purple200',
+    green: 'bg-green200',
+  };
+
+  const backgroundStyle = imageURL
+    ? {
+        backgroundImage: `url(${imageURL})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'top center',
+        backgroundRepeat: 'no-repeat',
+        filter: 'brightness(50%)',
+      }
+    : {};
+
+  const classes = clsx(
+    'min-h-screen w-full fixed z-[-1]',
+    backgroundStyle,
+    imageURL ? '' : colorTheme[color],
+  );
+
+  return <div className={classes} style={backgroundStyle} />;
+};
+
+export default Background;


### PR DESCRIPTION
## 📌 PR 개요

- `post/{id}` 페이지에서 background를 보이는 컴포넌트 구현

## 🔍 관련 이슈

- Closes #141

## 🔧 변경 유형

- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항

- `Layout.jsx` 파일 추가
- `Background.jsx` 작성

### `Background.jsx`
`props` | `type` | 설명
-- | -- | --
`color` | `string` | 배경 색상 (`beige`, `blue`, `purple`, `green` 중 하나)
`imageURL` | `string` | 배경 이미지 ( `null 혹은 http~~` )


## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 
### imageURL = {null}
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb1eb0c4-5bea-46ad-9fd2-dc8debec1864" />

### imageURL 값 있는 경우
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/95ca5da4-cfe6-4f37-94c5-aa0dee0b19c9" />

## 🤝 기타 참고 사항
