### PR TITLE
feat: 롤링페이퍼 message delete (#72)

### DIFF
--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -30,4 +30,5 @@ export const getMessageList = (recipientId = throwIfMissing('recipient_id'), opt
   });
 };
 
-export const deleteMessage = (id = throwIfMissing('id')) => api.delete(`${END_POINT}${id}/`);
+export const deleteMessage = (messageId = throwIfMissing('id')) =>
+  api.delete(`/19-8/messages/${messageId}/`);

--- a/src/pages/EditPage/EditPage.jsx
+++ b/src/pages/EditPage/EditPage.jsx
@@ -1,13 +1,30 @@
 import { useParams } from 'react-router-dom';
 
-const EditPage = () => {
-  const { id } = useParams();
+import Layout from '@/pages/Layout';
+import Background from '@/pages/PostedPage/components/Background/Background';
+import MessageCardList from '@/pages/PostedPage/components/MessageCardList/MessageCardList';
+import SubHeader from '@/pages/PostedPage/components/SubHeader/SubHeader';
+
+MessageCardList;
+
+const PostedPage = () => {
+  const { id: recipientId } = useParams();
 
   return (
-    <div>
-      <p> this is edit page.</p>
-    </div>
+    <Layout>
+      <Background color={'beige'} imageURL={'https://picsum.photos/id/1058/3840/2160'} />
+      <div className="flex min-h-screen flex-col">
+        {/* SubHeader 영역 */}
+        <div className="sticky top-[64px] z-40 w-full">
+          <SubHeader />
+        </div>
+        {/* 카드 리스트 영역 */}
+        <div className="mx-auto mt-8 w-full max-w-[1200px] p-5 sm:mt-8 sm:p-6 xl:mt-28 xl:p-0">
+          <MessageCardList recipientId={recipientId} isEditMode={true} />
+        </div>
+      </div>
+    </Layout>
   );
 };
 
-export default EditPage;
+export default PostedPage;

--- a/src/pages/PostedPage/PostedPage.jsx
+++ b/src/pages/PostedPage/PostedPage.jsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
-import Background from './components/Background/Background';
-import Layout from '../Layout';
-import SubHeader from './components/SubHeader/SubHeader';
-import MessageCardList from './components/MessageCardList/MessageCardList';
+import Layout from '@/pages/Layout';
+import Background from '@/pages/PostedPage/components/Background/Background';
+import MessageCardList from '@/pages/PostedPage/components/MessageCardList/MessageCardList';
+import SubHeader from '@/pages/PostedPage/components/SubHeader/SubHeader';
+
 const PostedPage = () => {
   const { id: recipientId } = useParams();
 

--- a/src/pages/PostedPage/components/MessageCard/MessageCard.jsx
+++ b/src/pages/PostedPage/components/MessageCard/MessageCard.jsx
@@ -6,8 +6,19 @@ import Profile from '@/components/Profile/Profile';
 
 import ModalWrapper from '../Modal/ModalWrapper';
 import MessageContent from '../Modal/MessageContent';
+import Button from '@/components/Button/Button';
 
-const MessageCard = ({ sender, profileImageURL, relationship, content, font, createdAt }) => {
+const MessageCard = ({
+  sender,
+  messageId,
+  profileImageURL,
+  relationship,
+  content,
+  font,
+  createdAt,
+  deletable = false,
+  onDelete,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const date = createdAt.slice(0, 10).replace(/-/g, '.');
 
@@ -26,15 +37,32 @@ const MessageCard = ({ sender, profileImageURL, relationship, content, font, cre
         {/* SENDER */}
         <div>
           {/* HEAD */}
-          <div className="mb-[15px] flex gap-[14px]">
-            <Profile src={profileImageURL} bordered />
-            <div>
-              <span className="flex gap-[6px]">
-                <span className="text-[20px] leading-6">From. </span>
-                <span className="text-[20px] leading-6 font-bold">{sender}</span>
-              </span>
-              <Badge relationship={relationship} />
+          <div className="mb-[15px] flex items-start">
+            <div className="flex flex-1 gap-[14px]">
+              <Profile src={profileImageURL} bordered />
+              <div>
+                <span className="flex gap-[6px]">
+                  <span className="text-[20px] leading-6">From. </span>
+                  <span className="text-[20px] leading-6 font-bold">{sender}</span>
+                </span>
+                <Badge relationship={relationship} />
+              </div>
             </div>
+            {/* DELETE */}
+            {deletable && (
+              <Button
+                variant="outlined"
+                size="custom"
+                paddingX={8}
+                paddingY={8}
+                iconName="delete"
+                className="ml-auto self-start rounded-[12px]"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete?.(messageId);
+                }}
+              />
+            )}
           </div>
           <Divider />
           {/* CONTENT */}

--- a/src/pages/PostedPage/components/MessageCardList/MessageCardList.jsx
+++ b/src/pages/PostedPage/components/MessageCardList/MessageCardList.jsx
@@ -4,11 +4,18 @@ import MessageCard from '@/pages/PostedPage/components/MessageCard/MessageCard';
 import Skeleton from '@/components/Skeleton/Skeleton';
 import usePaginatedMessages from '@/pages/PostedPage/hooks/usePaginatedMessages';
 import useInfiniteObserver from '@/pages/PostedPage/hooks/useIntersectionObserver';
-const MessageCardList = ({ recipientId }) => {
+import useDeleteMessage from '@/pages/PostedPage/hooks/useDeleteMessage';
+const MessageCardList = ({ recipientId, isEditMode }) => {
   // 데이터 로딩 훅
-  const { messages, isLoading, hasMore, loadMore } = usePaginatedMessages(recipientId, 8, 3);
+  const { messages, setMessages, isLoading, hasMore, loadMore } = usePaginatedMessages(
+    recipientId,
+    8,
+    3
+  );
   // 스크롤 감지 훅
   const observerRef = useInfiniteObserver(loadMore, isLoading, hasMore);
+  // 메세지 삭제
+  const { handleDelete, isDeleting } = useDeleteMessage(setMessages);
 
   return (
     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
@@ -24,13 +31,18 @@ const MessageCardList = ({ recipientId }) => {
       {messages.map((msg) => (
         <MessageCard
           key={msg.id}
+          messageId={msg.id}
           sender={msg.sender}
           profileImageURL={msg.profileImageURL}
           relationship={msg.relationship}
           content={msg.content}
           createdAt={msg.createdAt}
+          deletable={isEditMode}
+          onDelete={() => handleDelete(msg.id)}
         />
       ))}
+
+      {isDeleting && <p>삭제 중입니다...</p>}
 
       {/* 로딩  스켈레톤 */}
       {isLoading && (

--- a/src/pages/PostedPage/hooks/useDeleteMessage.js
+++ b/src/pages/PostedPage/hooks/useDeleteMessage.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { deleteMessage } from '@/api/messages';
+
+export default function useDeleteMessage(setMessages = () => {}) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async (messageId) => {
+    if (!window.confirm('정말 이 메시지를 삭제하시겠습니까?')) return;
+
+    try {
+      setIsDeleting(true);
+      await deleteMessage(messageId);
+      console.log('메시지 삭제 성공');
+
+      // 안전하게 setMessages 호출
+      setMessages((prev) => prev.filter((msg) => msg.id !== messageId));
+    } catch (error) {
+      console.error('메시지 삭제 실패:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return { handleDelete, isDeleting };
+}

--- a/src/pages/PostedPage/hooks/usePaginatedMessages.js
+++ b/src/pages/PostedPage/hooks/usePaginatedMessages.js
@@ -54,5 +54,5 @@ export default function usePaginatedMessages(recipientId, initialLimit = 8, next
     }
   }, [recipientId, loadMore]);
 
-  return { messages, isLoading, hasMore, loadMore };
+  return { messages, setMessages, isLoading, hasMore, loadMore };
 }


### PR DESCRIPTION
## 📌 PR 개요

- 롤링페이퍼 메세지 삭제 기능 구현

## 🔍 관련 이슈

- Closes #72

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [z] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- useDeleteMessage 훅 추가: 삭제 요청 및 삭제 후 상태 업데이트 로직 구현
- messages.js: deleteMessage API 수정 → DELETE /messages/{messageId}/ 엔드포인트 대응
- MessageCard: deletable prop 추가
- MessageCardList: isEditMode 전달 시 메시지 카드에 삭제 버튼 표시
- EditPage: 편집 모드 페이지에서 MessageCardList를 재사용
- 
## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)

현재는 아이디값뒤에 edit를 넣어야 들어갈수있습니다.