### PR TITLE
refactor: 카카오 공유 경로 수정 (#214)

### DIFF
--- a/src/pages/PostedPage/components/KakaoShareButton/KakaoShareButton.jsx
+++ b/src/pages/PostedPage/components/KakaoShareButton/KakaoShareButton.jsx
@@ -1,7 +1,14 @@
 import { useEffect } from 'react';
 
-export default function KakaoShareButton({ className, children, name, recipientId }) {
-  const url = 'https://rolling-xsll.vercel.app'; // 배포 주소
+export default function KakaoShareButton({
+  className,
+  children,
+  name,
+  recipientId,
+  messageCount,
+  reactionCount,
+}) {
+  const url = 'https://fe19-team8.netlify.app'; // 배포 주소
   const shareUrl = `${url}/redirect?to=/post/${recipientId}`;
 
   const images = [
@@ -33,10 +40,10 @@ export default function KakaoShareButton({ className, children, name, recipientI
           webUrl: shareUrl,
         },
       },
-      // social: {
-      //   likeCount: 10,
-      //   commentCount: 20,
-      // },
+      social: {
+        likeCount: reactionCount,
+        commentCount: messageCount,
+      },
       buttons: [
         {
           title: `${name}에게 롤링페이퍼 남기기`,

--- a/src/pages/PostedPage/components/Popover/PopoverContents/shareContent.jsx
+++ b/src/pages/PostedPage/components/Popover/PopoverContents/shareContent.jsx
@@ -3,7 +3,7 @@ import { showToast } from '@/utils/toast.js';
 import { PopoverContent } from './PopoverContent';
 import KakaoShareButton from '../../KakaoShareButton/KakaoShareButton.jsx';
 
-export const ShareContent = ({ name, recipientId }) => {
+export const ShareContent = ({ name, recipientId, messageCount, reactionCount }) => {
   const buttonClasses = `
     px-4 py-3 w-40 text-left
     hover:bg-gray100 hover:cursor-pointer
@@ -41,7 +41,13 @@ export const ShareContent = ({ name, recipientId }) => {
   return (
     <PopoverContent>
       <div className="mx-[1px] my-[10px] flex flex-col">
-        <KakaoShareButton className={buttonClasses} name={name} recipientId={recipientId}>
+        <KakaoShareButton
+          className={buttonClasses}
+          name={name}
+          recipientId={recipientId}
+          messageCount={messageCount}
+          reactionCount={reactionCount}
+        >
           카카오톡 공유
         </KakaoShareButton>
         <button className={buttonClasses} onClick={handleUrlShare}>

--- a/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
+++ b/src/pages/PostedPage/components/SubHeader/SubHeader.jsx
@@ -96,7 +96,13 @@ const SubHeader = ({ recipient, recipientId }) => {
           <div>
             <Popover>
               <PopoverTrigger type="share" />
-              <ShareContent emojis={reactions} name={name} recipientId={recipientId} />
+              <ShareContent
+                emojis={reactions}
+                name={name}
+                recipientId={recipientId}
+                messageCount={messageCount}
+                reactionCount={reactions.length}
+              />
             </Popover>
           </div>
         </div>


### PR DESCRIPTION
## 📌 PR 개요

- 배포 경로를 바꾸며 카카오 공유 경로를 수정합니다
- `social` 항목을 추가합니다

## 🔍 관련 이슈

- Closes #214
## 🔧 변경 유형
- [x] ♻️ refactor (리팩토링)

## ✨ 변경 사항

- 배포 경로 수정
- `social` 항목 추가
- 공유 링크 방문 시 진입점 수정 (`message` -> `post/{id}`)


## 📸 스크린샷
<img width="1170" height="2259" alt="image" src="https://github.com/user-attachments/assets/73706aa9-caba-425b-9d84-ac5b86fecace" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
